### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+README.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+/node_modules/
+/.idea/
+/doc/
+/coverage/
+/site
+/report/
+/.c9revisions/
+/.settings/
+
+.settings
+.classpath
+.project
+.metadata
+npm-debug.log
+.eslintcache

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,7 +66,7 @@ RUN \
 	# Ensure that Git is installed prior to running npm install
 	apt-get update && \
 	apt-get install -y git && \
-	npm install --production && \
+	npm install --unsafe-perm --production && \
 	# Remove Git and clean apt cache
 	apt-get clean && \
 	apt-get remove -y git && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,82 @@
+# Copyright 2020 Engineering Ingegneria Informatica S.p.A.
+#
+# This file is part of the IoT Agent for the Ultralight 2.0 protocol (IOTAUL) component
+#
+
+ARG NODE_VERSION=10.17.0-slim
+FROM node:${NODE_VERSION}
+ARG GITHUB_ACCOUNT=Engineering-Research-and-Development
+ARG GITHUB_REPOSITORY=opc-ua-car-server
+ARG DOWNLOAD=latest
+ARG SOURCE_BRANCH=master
+
+# Copying Build time arguments to environment variables so they are persisted at run time and can be 
+# inspected within a running container.
+# see: https://vsupalov.com/docker-build-time-env-values/  for a deeper explanation.
+
+ENV GITHUB_ACCOUNT=${GITHUB_ACCOUNT}
+ENV GITHUB_REPOSITORY=${GITHUB_REPOSITORY}
+ENV DOWNLOAD=${DOWNLOAD}
+
+MAINTAINER Engineering Ingegneria Informatica S.p.A.
+
+#
+# The following RUN command retrieves the source code from GitHub.
+# 
+# To obtain the latest stable release run this Docker file with the parameters
+# --no-cache --build-arg DOWNLOAD=stable
+# To obtain any speciifc version of a release run this Docker file with the parameters
+# --no-cache --build-arg DOWNLOAD=1.7.0
+#
+# The default download is the latest tip of the master of the named repository on GitHub
+#
+# Alternatively for local development, just copy this Dockerfile into file the root of the repository and 
+# replace the whole RUN statement by the following COPY statement in your local source using :
+#
+# COPY . /opt/opc-ua-car
+#
+RUN if [ "${DOWNLOAD}" = "latest" ] ; \
+	then \
+		RELEASE="${SOURCE_BRANCH}"; \
+		echo "INFO: Building Latest Development from ${SOURCE_BRANCH} branch."; \
+	elif [ "${DOWNLOAD}" = "stable" ]; \
+	then \
+		RELEASE=$(curl -s https://api.github.com/repos/"${GITHUB_ACCOUNT}"/"${GITHUB_REPOSITORY}"/releases/latest | grep 'tag_name' | cut -d\" -f4); \
+		echo "INFO: Building Latest Stable Release: ${RELEASE}"; \
+	else \
+	 	RELEASE="${DOWNLOAD}"; \
+	 	echo "INFO: Building Release: ${RELEASE}"; \
+	fi && \
+	RELEASE_CONCAT=$(echo "${RELEASE}" | tr / -); \
+	# Ensure that unzip is installed, and download the sources
+	apt-get update && \
+	apt-get install -y  --no-install-recommends unzip && \
+	wget --no-check-certificate -O source.zip https://github.com/"${GITHUB_ACCOUNT}"/"${GITHUB_REPOSITORY}"/archive/"${RELEASE}".zip && \
+	unzip source.zip && \
+	rm source.zip && \
+	mv "${GITHUB_REPOSITORY}-${RELEASE_CONCAT}" /opt/opc-ua-car && \
+	# Remove unzip and clean apt cache
+	apt-get clean && \
+	apt-get remove -y unzip && \
+	apt-get -y autoremove
+
+WORKDIR /opt/opc-ua-car
+
+RUN \
+	# Ensure that Git is installed prior to running npm install
+	apt-get update && \
+	apt-get install -y git && \
+	npm install --production && \
+	# Remove Git and clean apt cache
+	apt-get clean && \
+	apt-get remove -y git && \
+	apt-get -y autoremove && \
+	chmod +x docker/entrypoint.sh
+
+USER node
+ENV NODE_ENV=production
+
+# Expose 5001 for OPC-UA Car Server
+EXPOSE ${OPC-UA_PORT:-5001} 
+
+ENTRYPOINT ["docker/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -73,10 +73,10 @@ RUN \
 	apt-get -y autoremove && \
 	chmod +x docker/entrypoint.sh
 
-USER node
+# USER node
 ENV NODE_ENV=production
 
 # Expose 5001 for OPC-UA Car Server
-EXPOSE ${OPC-UA_PORT:-5001} 
+EXPOSE 5001
 
 ENTRYPOINT ["docker/entrypoint.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,15 +3,15 @@
 [![FIWARE IoT Agents](https://nexus.lab.fiware.org/repository/raw/public/badges/chapters/iot-agents.svg)](https://www.fiware.org/developers/catalogue/)
 [![](https://nexus.lab.fiware.org/repository/raw/public/badges/stackoverflow/iot-agents.svg)](https://stackoverflow.com/questions/tagged/fiware+iot)
 
-A simple server that represents a car with the follow structure:
+A simple [OPC-UA](https://opcfoundation.org/about/opc-technologies/opc-ua/) server that simulates a car with the following structure:
 
--   Car (obj)
-    -   Speed (attr)
-    -   Accelerate (meth)
-    -   Stop (meth)
-    -   Engine (obj)
-        -   Temperature (attr)
-        -   Oxygen (attr)
+-   Car (object)
+    -   Speed (attribute)
+    -   Accelerate (method)
+    -   Stop (method)
+    -   Engine (object)
+        -   Temperature (attribute)
+        -   Oxygen (attribute)
     -   Sensors
         -   Any number of user-defined sensors
 
@@ -28,3 +28,42 @@ A simple server that represents a car with the follow structure:
 | Decelerated                  | On        | < 0          | Varies with speed                                                                                                                             | Tends to 80 °C      | Varies with deceleration |
 | In motion (Decelerated)      | Off       | 0            | 0 (Transmission Neutral / Engine Brake)                                                                                                       | Tends to 20 °C      | Tends to 0               |
 | From decelerated to constant | Off -> On | 0            | Follows the current speed                                                                                                                     | Tends to 80 °C      | Constant                 |
+
+
+
+## How to build an image
+
+The [Dockerfile](https://github.com/Engineering-Research-and-Development/opc-ua-car-server/blob/master/docker/Dockerfile) associated with this image
+can be used to build an image in several ways:
+
+-   By default, the `Dockerfile` retrieves the **latest** version of the codebase direct from GitHub (the `build-arg` is
+    optional):
+
+```console
+docker build -t opc-ua-car-server . --build-arg DOWNLOAD=latest
+```
+
+-   You can alter this to obtain the last **stable** release run this `Dockerfile` with the build argument
+    `DOWNLOAD=stable`
+
+```console
+docker build -t opc-ua-car-server . --build-arg DOWNLOAD=stable
+```
+
+-   You can also download a specific release by running this `Dockerfile` with the build argument `DOWNLOAD=<version>`
+
+```console
+docker build -t opc-ua-car-server . --build-arg DOWNLOAD=1.3.4
+```
+
+## Building from your own fork
+
+To download code from your own fork of the GitHub repository add the `GITHUB_ACCOUNT`, `GITHUB_REPOSITORY` and
+`SOURCE_BRANCH` arguments (default `master`) to the `docker build` command.
+
+```console
+docker build -t opc-ua-car-server . \
+    --build-arg GITHUB_ACCOUNT=<your account> \
+    --build-arg GITHUB_REPOSITORY=<your repo> \
+    --build-arg SOURCE_BRANCH=<your branch>
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,30 @@
+# OPC UA CAR SERVER with NodeOPCUA
+
+[![FIWARE IoT Agents](https://nexus.lab.fiware.org/repository/raw/public/badges/chapters/iot-agents.svg)](https://www.fiware.org/developers/catalogue/)
+[![](https://nexus.lab.fiware.org/repository/raw/public/badges/stackoverflow/iot-agents.svg)](https://stackoverflow.com/questions/tagged/fiware+iot)
+
+A simple server that represents a car with the follow structure:
+
+-   Car (obj)
+    -   Speed (attr)
+    -   Accelerate (meth)
+    -   Stop (meth)
+    -   Engine (obj)
+        -   Temperature (attr)
+        -   Oxygen (attr)
+    -   Sensors
+        -   Any number of user-defined sensors
+
+![Car Schema](https://github.com/Engineering-Research-and-Development/opc-ua-car-server/blob/master/img/car_schema.png)
+
+### Car model behavioural specs
+
+| Motion Status                | Engine    | Acceleration | Oxigen                                                                                                                                        | Temperature         | Speed                    |
+| ---------------------------- | --------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- | ------------------------ |
+| Stopped                      | Off       | 0            | 0                                                                                                                                             | Environmental 20 °C | 0                        |
+| Stopped                      | On        | 0            | 5                                                                                                                                             | Tends to 80 °C      | 0                        |
+| Accelerated                  | On        | > 0          | Varies with speed. When the acceleration increases an overshoot is triggered, otherwise if acceleration decreases an undershoot is triggered. | Tends to 80 °C      | Varies with acceleration |
+| Constant                     | On        | 0            | Constant                                                                                                                                      | Tends to 80 °C      | Constant                 |
+| Decelerated                  | On        | < 0          | Varies with speed                                                                                                                             | Tends to 80 °C      | Varies with deceleration |
+| In motion (Decelerated)      | Off       | 0            | 0 (Transmission Neutral / Engine Brake)                                                                                                       | Tends to 20 °C      | Tends to 0               |
+| From decelerated to constant | Off -> On | 0            | Follows the current speed                                                                                                                     | Tends to 80 °C      | Constant                 |

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+# Copyright 2020 Engineering Ingegneria Informatica S.p.A.
+#
+node car.js

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+# Copyright 2020 Engineering Ingegneria Informatica S.p.A.
+#
+docker build --build-arg SOURCE_BRANCH=$SOURCE_BRANCH -t $IMAGE_NAME .


### PR DESCRIPTION
This PR adds a Dockerfile and Docker README to the simulated OPC-UA Car.

The Dockerfile can also be  modified and used to create an image from root so users can modify the existing code and run the server against their own branch.

- Added GitIgnore
- Added DockerIgnore
- Added Docker README.md

**Note:** The Dockerization is **insecure** since the node application is running as root. 